### PR TITLE
Fix github coverage actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Upload coverage data
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-data
+        name: coverage-data-${{ matrix.python-version }}
         path: '.coverage.*'
 
   coverage:
@@ -65,11 +65,13 @@ jobs:
       - name: Download data
         uses: actions/download-artifact@v4
         with:
-          name: coverage-data
+          path: coverage-data
+          pattern: coverage-data-*
+          merge-multiple: true
 
       - name: Combine coverage and fail if it's <100%
         run: |
-          python -m coverage combine
+          python -m coverage combine coverage-data
           python -m coverage html --skip-covered --skip-empty
           python -m coverage report --fail-under=100
 


### PR DESCRIPTION
Recent dependabot upgrades introduced breaking changes in `actions/upload-artifact` and `actions/download-artifact`.

This change fixes the problems, following the [migration instructions](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md).